### PR TITLE
Add Apptainer usage instructions and Dockerfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,19 +7,16 @@ set(CMAKE_CXX_STANDARD 17)
 include_directories(${CMAKE_SOURCE_DIR}/external/install/include)
 link_directories(${CMAKE_SOURCE_DIR}/external/install/lib64)
 
-# Define Leiden wrapper executable
-add_executable(leiden_test src/leiden_wrapper.cpp src/run_leiden.cpp)
+# Define relative runtime path
+set(CMAKE_INSTALL_RPATH "$ORIGIN/../external/install/lib64")
+set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
 
 # Define new clustering executable
+add_executable(leiden_test src/leiden_wrapper.cpp src/run_leiden.cpp)
 add_executable(leiden_clustering src/leiden_clustering.cpp src/run_leiden.cpp)
 
 # Link with igraph and libleidenalg
-target_link_libraries(leiden_test
-    ${CMAKE_SOURCE_DIR}/external/install/lib64/libigraph.a
-    ${CMAKE_SOURCE_DIR}/external/install/lib64/liblibleidenalg.so
-)
-target_link_libraries(leiden_clustering
-    ${CMAKE_SOURCE_DIR}/external/install/lib64/libigraph.a
-    ${CMAKE_SOURCE_DIR}/external/install/lib64/liblibleidenalg.so
-)
-
+target_link_libraries(leiden_test igraph libleidenalg)
+target_link_libraries(leiden_clustering igraph libleidenalg)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:25.04
+
+RUN apt-get update && apt-get install -y \
+    libgomp1 \
+    libxml2 \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY . .
+
+CMD ["./build/leiden_test"]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Run the following script to build everything at once:
 make sure you loaded the intel module
 ```bash
 module load intel
-
+module load CMake/3.31.3
 bash setup.sh
 ```
 This script will:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Once everything is compiled, run the Leiden clustering test:
 Expected output:
 ```bash
 
-./bin/leiden_clustering -t cpm -r 0.5 input.tsv output.tsv
+./build/leiden_clustering -t cpm -r 0.5 input.tsv output.tsv
 ```
 Starting Leiden algorithm...
 Leiden clustering complete.

--- a/README.md
+++ b/README.md
@@ -104,3 +104,11 @@ export LIBRARY_PATH=/home/$USER/arkouda-njit/arachne/server/Clustering_Algorithm
 export CPATH=/home/$USER/arkouda-njit/arachne/server/Clustering_Algorithms/external/install/include:$CPATH
 ```
 
+## Run with Apptainer on Wulver
+
+You can run the project using **Apptainer** on the Wulver system with the following commands:
+
+```bash
+module load apptainer
+apptainer pull cluster-algorithm.sif docker://spoiler2400/cluster-algorithm:1.0.0
+apptainer exec cluster-algorithm.sif /app/build/leiden_clustering -t cpm -r 0.5 input.tsv output.tsv

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ make
 
 If you faced any problem you can do something like this to modify your environment to include the library paths:
 ```bash
-export LD_LIBRARY_PATH=/home/md724/arkouda-njit/arachne/server/Clustering_Algorithms/external/install/lib64:$LD_LIBRARY_PATH
-export LIBRARY_PATH=/home/md724/arkouda-njit/arachne/server/Clustering_Algorithms/external/install/lib64:$LIBRARY_PATH
-export CPATH=/home/md724/arkouda-njit/arachne/server/Clustering_Algorithms/external/install/include:$CPATH
+export LD_LIBRARY_PATH=/home/$USER/arkouda-njit/arachne/server/Clustering_Algorithms/external/install/lib64:$LD_LIBRARY_PATH
+export LIBRARY_PATH=/home/$USER/arkouda-njit/arachne/server/Clustering_Algorithms/external/install/lib64:$LIBRARY_PATH
+export CPATH=/home/$USER/arkouda-njit/arachne/server/Clustering_Algorithms/external/install/include:$CPATH
 ```
 


### PR DESCRIPTION
- Added a new "Run Using Apptainer on Wulver" section to README.md
- Added a Dockerfile to support container-based builds
- Refactored CMakeLists.txt to use relative paths
- Updated library paths to reference the $USER variable
- Updated leiden_clustering command path